### PR TITLE
Fix `invalid UTF-8 byte sequence` when deploy with Amazon OpsWorks

### DIFF
--- a/vendor/assets/javascripts/date/date.js
+++ b/vendor/assets/javascripts/date/date.js
@@ -7,7 +7,7 @@
  *     date.js       // English (United States)
  *     date-en-US.js // English (United States)
  *     date-de-DE.js // Deutsch (Deutschland)
- *     date-es-MX.js // français (France)
+ *     date-es-MX.js // franÃ§ais (France)
  */
 
 alert(
@@ -17,5 +17,5 @@ alert(
     "    date.js       // English (United States)\n" + 
     "    date-en-US.js // English (United States)\n" + 
     "    date-de-DE.js // Deutsch (Deutschland)\n" + 
-    "    date-es-MX.js // français (France)\n"
+    "    date-es-MX.js // franÃ§ais (France)\n"
     );


### PR DESCRIPTION
Fix `Sprockets::EncodingError: vendor/assets/javascripts/date/date.js has a invalid UTF-8 byte sequence` when deploy with Amazon OpsWorks

Saved date.js as UTF-8 encoding & Unix line ending instead of Western/Windows line ending
